### PR TITLE
statically set spamassassin version on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x && \
     apk upgrade && \
     apk add -t .spamassassin-run-deps \
            razor \
-           spamassassin \
+           spamassassin=3.4.6-r4 \
            && \
    \
     mkdir -p /assets/spamassassin && \


### PR DESCRIPTION
I'm not sure if this would break anything, but I'm hoping to leverage your image while still having the ability to track what version is actually installed on the image without having to get into the container to verify that. 

I'm aware that you're keeping this in more or less maintenance mode, but this seemed like a small change that I'd be willing to keep track of if needed.

